### PR TITLE
fix hide_sitewide switch to check for post_status="publish" rather than "public"

### DIFF
--- a/includes/activity.php
+++ b/includes/activity.php
@@ -85,7 +85,7 @@ function bpeo_create_activity_for_event( $event_id, $event = null, $update = nul
 			break;
 	}
 
-	$hide_sitewide = 'public' !== $event->post_status;
+	$hide_sitewide = 'publish' !== $event->post_status;
 
 	$activity_args = array(
 		'component' => 'events',


### PR DESCRIPTION
I found that new event activities are hidden incorrectly using this plugin because the value of post_status is "publish" rather than "public" when a post is public. When it's private, the value is "private". This patch just switches the values for what's actually there, so that hide_sitewide is only enabled if the event is not public.