### PR TITLE
Introduce "bpeo_edit_screen_before_display" action

### DIFF
--- a/includes/class.bpeo_frontend_admin_screen.php
+++ b/includes/class.bpeo_frontend_admin_screen.php
@@ -60,6 +60,13 @@ class BPEO_Frontend_Admin_Screen extends WP_Frontend_Admin_Screen {
 		if ( class_exists( 'Shortcode_UI', false ) && is_callable( array( Shortcode_UI::get_instance(), 'action_media_buttons' ) ) ) {
 			remove_action( 'media_buttons', array( Shortcode_UI::get_instance(), 'action_media_buttons' ) );
 		}
+
+		/**
+		 * Broadcast that the edit screen is about to be rendered.
+		 *
+		 * @since 0.2
+		 */
+		do_action( 'bpeo_edit_screen_before_display' );
 	}
 
 	/**


### PR DESCRIPTION
@r-a-y This is a bit of an oddity - I can't seem to find an appropriate hook that tells me that I'm on a BPEO edit screen. Please ignore this PR if there's a hook that I've overlooked.

FWIW, the reason for introducing this hook (or a hook like it) is that (due to a limitation in CiviCRM) I use [Radio Buttons for Taxonomies](https://wordpress.org/plugins/radio-buttons-for-taxonomies/) to force events to have only a single category assigned to them. RBfT transforms the Category metabox by unhooking the built-in one and replacing it with an amended version, but does so via the `admin_menu` hook - which, of course, does not fire on the front end. The relevant RBfT method can be called directly, but it seems overkill to do so unless it's needed.