### PR TITLE
Use proper variable name when populating group widget dropdown.

### DIFF
--- a/bp-event-organiser-group-widget.php
+++ b/bp-event-organiser-group-widget.php
@@ -430,7 +430,7 @@ class BPEO_Group_Widget extends WP_Widget {
 				<option value="" <?php selected( $group_id, '' ); ?>><?php esc_html_e( '--- Select a group ---', 'bpeo-group-widget' ); ?></option>
 
 				<?php foreach ( $groups as $i => $group_name ) : ?>
-					<option value="<?php echo esc_attr( $i ); ?>" <?php selected( $group_id, $i ); ?>><?php echo esc_html( $group->name ); ?></option>
+					<option value="<?php echo esc_attr( $i ); ?>" <?php selected( $group_id, $i ); ?>><?php echo esc_html( $group_name ); ?></option>
 				<?php endforeach; ?>
 			</select></p>
 


### PR DESCRIPTION
`$group` is not an object in this context.

@r-a-y Can you review and make sure I'm not crazy? :)