### PR TITLE
Prevent fatal error on loops subsequent to single event

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -452,10 +452,20 @@ add_filter( 'template_include', 'bpeo_remove_default_canonical_event_content', 2
  * @see bpeo_remove_default_canonical_event_content()
  *
  * @param  string $content Current content.
- * @return string
+ * @return string $content The modified content.
  */
 function bpeo_canonical_event_content( $content ) {
 	global $pages;
+
+	// bail if not canonical event
+	if ( ! is_singular( 'event' ) ) {
+		return $content;
+	}
+
+	// bail if not event post type
+	if ( get_post_type( get_the_ID() ) != 'event' ) {
+		return $content;
+	}
 
 	// reset get_the_content() to use already-rendered content so we can use it in
 	// our content-eo-event.php template part


### PR DESCRIPTION
Discovered a fatal error when I added a "Featured Post" type of widget to a theme where the sidebar that is rendered after the main column.

BPEO's `the_content` filter does not test for the `post_type` and therefore throws `PHP Fatal error:  Uncaught exception 'Exception' with message 'Error in formating DateTime object. Expected DateTime, but instead given boolean' in /path/to/event-organiser-utility-functions.php:31` when the widget calls `the_content` for a `post_type` other than `event`. Although the error doesn't look related to this, it is thrown because a `post` does not have the required meta.