### PR TITLE
Groups: Give members read access to private events that they are a member of

### DIFF
--- a/includes/group.php
+++ b/includes/group.php
@@ -332,6 +332,30 @@ function bpeo_group_event_meta_cap( $caps, $cap, $user_id, $args ) {
 
 			break;
 
+		/*
+		 * Give group members access to private events in their private groups. Ugh.
+		 */
+		case 'read_private_events' :
+			if ( ! bp_is_group() ) {
+				return $caps;
+			}
+
+			$can_access = false;
+			$group = groups_get_current_group();
+
+			if ( isset( buddypress()->groups->current_group->is_user_member ) ) {
+				$can_access = buddypress()->groups->current_group->is_user_member;
+
+			} elseif ( groups_is_user_member( bp_loggedin_user_id(), $group->id ) ) {
+				$can_access = true;
+			}
+
+			if ( is_super_admin() || $can_access ) {
+				$caps = array( 'read' );
+			}
+
+			break;
+
 		case 'read_event' :
 			// we've already parsed this logic in bpeo_map_basic_meta_caps()
 			if ( 'exist' === $caps[0] ) {


### PR DESCRIPTION
A user reported an issue with events created in private groups.

If a group member creates an event in a private group, other members of that group cannot view the event on the group event calendar.

The issue is due to the event being created with the `private` post status and WordPress doing a check on the `read_private_events` cap when our AJAX query runs to display events on the group calendar.

The interesting thing is the "Events > Upcoming" page does not require the `read_private_posts` cap check as we use `eo_get_events()` to grab the events and not the WP query loop.

The approach I've used in the PR is similar to what we do with the `read_group_events` cap check.  I'm basically duplicating portions of that code to appease WordPress here.

Could use your feedback here, @boonebgorges 