### PR TITLE
Feature: Group Event Import

### DIFF
--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -25,6 +25,7 @@ div.manage-icalendar .row-actions span.delete a {
 div.manage-icalendar .widefat td,
 div.manage-icalendar .widefat th {
 	padding: 8px 10px;
+	text-align: left;
 }
 
 .eo-advanced-feed-options-toggle {

--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -36,7 +36,8 @@ div.manage-icalendar-ics label {
 	display: block;
 }
 
-div.manage-icalendar-feeds .hide-if-js {
+div.manage-icalendar-feeds .hide-if-js,
+div.manage-icalendar-feeds label[for="sync-schedule"] {
 	display: none;
 }
 

--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -1,0 +1,64 @@
+body.bp-legacy div.manage-icalendar h3 {
+	background: #555;
+	color: #fff;
+	padding: 0.2em;
+}
+
+body.bp-nouveau div.manage-icalendar h3 {
+	margin-top: 2em;
+}
+
+div.manage-icalendar .widefat a {
+	font-size: 95%;
+	text-decoration: none;
+}
+
+div.manage-icalendar .row-actions .delete a:hover {
+	color: #dc3232;
+	border: none;
+}
+
+div.manage-icalendar .row-actions span.delete a {
+	color: #a00;
+}
+
+div.manage-icalendar .widefat td,
+div.manage-icalendar .widefat th {
+	padding: 8px 10px;
+}
+
+.eo-advanced-feed-options-toggle,
+div.manage-icalendar-ics label {
+	display: inline-block;
+}
+
+.eo-advanced-feed-options-toggle,
+#eo-advanced-feed-options-wrap {
+	margin-bottom: 2em;
+}
+
+div.manage-icalendar-ics label {
+	margin-bottom: 1em;
+}
+
+/* hide some post statuses that are not applicable to us */
+div.manage-icalendar #feed-status option[value="draft"],
+div.manage-icalendar #feed-status option[value="pending"] {
+	display: none;
+}
+
+/* hide categories if we've disabled them */
+div.disable-eo-categories label[for="feed-category"],
+div.disable-eo-categories #feed-category,
+div.disable-eo-categories .inline-edit-col label:nth-child(5) {
+	/* nth-child(5) is such a hack... */
+	display: none;
+}
+
+/* hide venues if we've disabled them */
+div.disable-eo-venues label[for="feed-venue"],
+div.disable-eo-venues #feed-venue,
+div.disable-eo-venues .inline-edit-col label:nth-child(6) {
+	/* nth-child(6) is such a hack... */
+	display: none;
+}

--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -69,3 +69,12 @@ div.disable-eo-venues .inline-edit-col label:nth-child(6) {
 	/* nth-child(6) is such a hack... */
 	display: none;
 }
+
+/* hide post status field */
+div.manage-icalendar label[for="feed-status"],
+div.manage-icalendar #feed-status,
+div.manage-icalendar #feed-status option[value="draft"],
+div.manage-icalendar #feed-status option[value="pending"],
+div.manage-icalendar-feeds .inline-edit-col label:nth-child(7) {
+	display: none;
+}

--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -48,9 +48,10 @@ div.manage-icalendar-ics label {
 	margin-bottom: 1em;
 }
 
-/* hide some post statuses that are not applicable to us */
-div.manage-icalendar #feed-status option[value="draft"],
-div.manage-icalendar #feed-status option[value="pending"] {
+/* hide organiser if we've disabled it */
+div.disable-eo-organiser label[for="feed-organiser"],
+div.disable-eo-organiser #feed-organiser,
+div.disable-eo-organiser .inline-edit-col label:nth-child(4) {
 	display: none;
 }
 

--- a/assets/css/group-manage-ical.css
+++ b/assets/css/group-manage-ical.css
@@ -1,10 +1,10 @@
-body.bp-legacy div.manage-icalendar h3 {
+body.bp-legacy #buddypress div.manage-icalendar h3 {
 	background: #555;
 	color: #fff;
 	padding: 0.2em;
 }
 
-body.bp-nouveau div.manage-icalendar h3 {
+div.manage-icalendar {
 	margin-top: 2em;
 }
 
@@ -27,14 +27,20 @@ div.manage-icalendar .widefat th {
 	padding: 8px 10px;
 }
 
-.eo-advanced-feed-options-toggle,
-div.manage-icalendar-ics label {
+.eo-advanced-feed-options-toggle {
 	display: inline-block;
 }
 
-.eo-advanced-feed-options-toggle,
-#eo-advanced-feed-options-wrap {
-	margin-bottom: 2em;
+div.manage-icalendar-ics label {
+	display: block;
+}
+
+div.manage-icalendar-feeds .hide-if-js {
+	display: none;
+}
+
+#add-eo-feed-submit {
+	margin-top: 2em;
 }
 
 div.manage-icalendar-ics label {

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -709,7 +709,6 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 
 		// Check for validation message and remove some filters.
 		if ( isset( buddypress()->template_message ) ) {
-			remove_filter( 'bp_core_render_message_content', 'wpautop' );
 			remove_filter( 'bp_core_render_message_content', 'wp_kses_data', 5 );
 		}
 

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -93,8 +93,8 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 				'enable_create_step' => false,
 			);
 
-			// Only register the "Manage > Events" screen for non-public groups.
-			if ( bp_is_group() && 'public' !== bp_get_group_status( groups_get_current_group() ) ) {
+			// Register the "Manage > Events" screen.
+			if ( bp_is_group() ) {
 				$args['screens'] = array(
 					'edit' => array(
 						'enabled' => true,
@@ -174,19 +174,15 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 			'link'            => bpeo_get_group_permalink() . 'upcoming/',
 		), $default_params );
 
-		// Show 'Manage' tab if group is not public
-		if ( 'public' !== bp_get_group_status( groups_get_current_group() ) ) {
-			// We only allow group admins to see this tab
-			$admin_ids = bp_group_admin_ids( groups_get_current_group(), 'array' );
-
-			$sub_nav[] = array_merge( array(
-				'name'            => __( 'Manage', 'bp-event-organiser' ),
-				'slug'            => 'manage',
-				'user_has_access' => in_array( bp_loggedin_user_id(), $admin_ids ),
-				'position'        => 0,
-				'link'            => trailingslashit( bp_get_group_permalink( groups_get_current_group() ) . 'admin/' . $this->params['slug'] ),
-			), $default_params );
-		}
+		// We only allow group admins to see the Manage tab
+		$admin_ids = bp_group_admin_ids( groups_get_current_group(), 'array' );
+		$sub_nav[] = array_merge( array(
+			'name'            => __( 'Manage', 'bp-event-organiser' ),
+			'slug'            => 'manage',
+			'user_has_access' => in_array( bp_loggedin_user_id(), $admin_ids ),
+			'position'        => 0,
+			'link'            => trailingslashit( bp_get_group_permalink( groups_get_current_group() ) . 'admin/' . $this->params['slug'] ),
+		), $default_params );
 
 		// @todo This should probably use a custom cap instead of membership check.
 		$sub_nav[] = array_merge( array(

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -678,11 +678,15 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 					// Bypass permission checks for event creation.
 					add_filter( 'map_meta_cap', array( $this, 'bypass_permission_checks' ), 10, 4 );
 
+					// Prevent activity items from being generated.
+					add_action( 'bp_activity_before_save', array( $this, 'block_activity_saving' ), 0 );
+
 					// Import the iCalendar file.
 					$import = Event_Organiser_Im_Export::get_object();
 					$import->import_file( $_FILES['ics']['tmp_name'] );
 
-					remove_filter( 'map_meta_cap', array( $this, 'bypass_permission_checks' ), 10 );
+					remove_filter( 'map_meta_cap',            array( $this, 'bypass_permission_checks' ), 10 );
+					remove_action( 'bp_activity_before_save', array( $this, 'block_activity_saving' ), 0 );
 				}
 
 			} elseif ( ! isset( $_FILES ) || empty( $_FILES['ics']['name'] ) ) {
@@ -787,6 +791,20 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 				'post_status' => 'private'
 			) );
 		}
+	}
+
+	/**
+	 * Block activity items from being created.
+	 *
+	 * To block activity items, we wipe out the activity's component property.
+	 * BuddyPress will then prevent the item from being created.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param object $activity Activity item before being saved.
+	 */
+	public function block_activity_saving( $activity ) {
+		$activity->component = false;
 	}
 
 	/**

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -731,10 +731,10 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 	?>
 
 		<div class="manage-icalendar manage-icalendar-ics">
-			<h3><?php esc_html_e( 'Import Events from iCalendar File', 'bp-event-organiser' ); ?></h3>
+			<h3><?php esc_html_e( 'Event Import', 'bp-event-organiser' ); ?></h3>
 
 			<form method="post" action="" enctype="multipart/form-data">
-				<p><?php esc_html_e( "Select an iCalendar file that you would like to import into the group's calendar. The file should be an .ics file.", 'bp-event-organiser' ); ?></p>
+				<p><?php esc_html_e( "Perform a one-time import of one or more events into your group's calendar. Select an .ics file to get started.", 'bp-event-organiser' ); ?></p>
 
 				<?php if ( taxonomy_exists( 'event-venue' ) && bpeo_is_import_venues_enabled() ) : ?>
 					<label><input type="checkbox" name="eo_import_venue" value="1" /> <?php _e( 'Import and create venues if they do not exist', 'bp-event-organiser' ); ?></label>

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -124,6 +124,11 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 		}
 
 		$this->register_subnav();
+
+		// Import ICS
+		if ( class_exists( 'Event_Organiser_Im_Export' ) ) {
+			add_action( 'bp_actions', array( $this, 'manage_events_import_ics' ), 7 );
+		}
 	}
 
 	/**
@@ -607,7 +612,7 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 	 * @param int $group_id ID of the group.
 	 */
 	public function edit_screen_callback( $group_id = null ) {
-
+		// Non-private groups get a "Manage iCalendar settings" section.
 		if ( 'public' !== bp_get_group_status( groups_get_current_group() ) ) {
 			// use our template stack
 			add_filter( 'eventorganiser_template_stack', 'bpeo_register_template_stack' );
@@ -626,6 +631,189 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 	 * @param int $group_id ID of the group.
 	 */
 	public function edit_screen_save_callback( $group_id = null ) {
+	}
+
+	/**
+	 * Import iCalendar ICS section on "Manage > Events" screen.
+	 *
+	 * We're running this on 'bp_actions' at priority 7 so we can do our own
+	 * validation routine ahead of the BP Group Extension API. The reason we need
+	 * to do this is we run a custom <form> and the Group Extension API already
+	 * includes a <form> for us, so we can't do our thing with the native API.
+	 *
+	 * @since 1.1.0
+	 */
+	public function manage_events_import_ics() {
+		// If not on our "Manage > Events" page, bail.
+		if ( ! is_user_logged_in() || true !== ( bp_is_groups_component() && bp_is_current_action( 'admin' ) && bp_is_action_variable( $this->params['slug'], 0 ) ) ) {
+			return;
+		}
+
+		/*
+		 * Upload validation routine.
+		 *
+		 * This part is mostly a dupe of Event_Organiser_Im_Export::__construct() with
+		 * some mods to handle BP groups and notice rendering.
+		 */
+		if ( ! empty( $_POST['eventorganiser_import_events'] ) && wp_verify_nonce( $_POST['bpeo_group_import_nonce'], 'eventorganiser_import_events' ) ) {
+			global $EO_Errors;
+			$EO_Errors = new WP_Error();
+
+			// Perform checks on file.
+			if ( in_array( $_FILES["ics"]["type"], array( "text/calendar", "application/octet-stream" ) ) && ( $_FILES["ics"]["size"] < 2097152 ) ) {
+				if ( $_FILES["ics"]["error"] > 0 ) {
+					$EO_Errors = new WP_Error( 'eo_error', sprintf( __( "File Error encountered: %d", 'bp-event-organiser' ), $_FILES["ics"]["error"] ) );
+
+				// Import file.
+				} else {
+					// Add some meta to imported event.
+					add_action( 'eventorganiser_created_event', array( $this, 'add_meta_to_imported_event' ) );
+
+					// Bypass permission checks for event creation.
+					add_filter( 'map_meta_cap', array( $this, 'bypass_permission_checks' ), 10, 4 );
+
+					// Import the iCalendar file.
+					$import = Event_Organiser_Im_Export::get_object();
+					$import->import_file( $_FILES['ics']['tmp_name'] );
+
+					remove_filter( 'map_meta_cap', array( $this, 'bypass_permission_checks' ), 10 );
+				}
+
+			} elseif ( ! isset( $_FILES ) || empty( $_FILES['ics']['name'] ) ) {
+				$EO_Errors = new WP_Error( 'eo_error', __( "No file detected.", 'bp-event-organiser' ) );
+
+			} else {
+				$EO_Errors = new WP_Error( 'eo_error', __( "Invalid file uploaded. The file must be a ics calendar file of type 'text/calendar', no larger than 2MB.", 'bp-event-organiser' ) );
+				$size = size_format( $_FILES["ics"]["size"], 2 );
+				$details = sprintf( __( 'File size: %s. File type: %s', 'bp-event-organiser' ), $size, $_FILES["ics"]["type"] );
+				$EO_Errors->add( 'eo_error', $details );
+			}
+
+			$errors  = $EO_Errors->get_error_messages( 'eo_error' );
+			$notices = $EO_Errors->get_error_messages( 'eo_notice' );
+
+			if ( ! empty( $errors ) ) {
+				bp_core_add_message( sprintf( '<p>%s</p>', implode( '</p><p>', $errors ) ), 'error' );
+			} elseif ( ! empty( $notices ) ) {
+				bp_core_add_message( sprintf( '<p>%s</p>', implode( '</p><p>', $notices ) ) );
+			}
+
+			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/' . $this->params['slug'] . '/' );
+		}
+
+		// Check for validation message and remove some filters.
+		if ( isset( buddypress()->template_message ) ) {
+			remove_filter( 'bp_core_render_message_content', 'wpautop' );
+			remove_filter( 'bp_core_render_message_content', 'wp_kses_data', 5 );
+		}
+
+		// Load display hook.
+		add_action( 'bp_after_group_body', array( $this, 'manage_events_display_import_ics' ), 20 );
+	}
+
+	/**
+	 * Display hook for import iCalendar ICS section on "Manage > Events" screen.
+	 *
+	 * Mostly duplicated from Event_Organiser_Im_Export::get_im_export_markup().
+	 *
+	 * @since 1.1.0
+	 */
+	public function manage_events_display_import_ics() {
+	?>
+
+		<div class="manage-icalendar manage-icalendar-ics">
+			<h3><?php esc_html_e( 'Import Events from iCalendar File', 'bp-event-organiser' ); ?></h3>
+
+			<form method="post" action="" enctype="multipart/form-data">
+				<p><?php esc_html_e( "Select an iCalendar file that you would like to import into the group's calendar. The file should be an .ics file.", 'bp-event-organiser' ); ?></p>
+
+				<?php if ( taxonomy_exists( 'event-venue' ) && bpeo_is_import_venues_enabled() ) : ?>
+					<label><input type="checkbox" name="eo_import_venue" value="1" /> <?php _e( 'Import and create venues if they do not exist', 'bp-event-organiser' ); ?></label>
+
+				<?php endif; ?>
+
+				<?php if ( bpeo_is_import_categories_enabled() ) : ?>
+					<label><input type="checkbox" name="eo_import_cat" value="1" /> <?php _e( 'Import and create event categories if they do not exist', 'bp-event-organiser' ); ?></label>
+
+				<?php endif; ?>
+
+				<p><input type="file" name="ics" accept=".ics" /></p>
+
+				<?php wp_nonce_field( 'eventorganiser_import_events', 'bpeo_group_import_nonce' ); ?>
+
+				<?php bp_button( array(
+					'id' => 'bpeo-group-import-events',
+					'component' => 'groups',
+					'block_self' => false,
+					'button_element' => 'input',
+					'button_attr' => array(
+						'type'  => 'submit',
+						'name'  => 'eventorganiser_import_events',
+						'id'    => 'eventorganiser_import_events',
+						'class' => 'button',
+						'value' => esc_attr( 'Import', 'bp-event-organiser' )
+					),
+				) ); ?>
+			</form>
+
+		</div>
+
+	<?php
+	}
+
+	/**
+	 * Callback to connect an imported event via ICS to a group.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Event post ID.
+	 */
+	public function add_meta_to_imported_event( $post_id ) {
+		// Connect the event to the group.
+		bpeo_connect_event_to_group( $post_id, bp_get_current_group_id() );
+
+		// Save the filename into event meta, just in case.
+		update_post_meta( $post_id, '_eventorganiser_import_filename', $_FILES['ics']['name'] );
+
+		// Ensure events imported in a private group are private.
+		if ( 'public' !== bp_get_group_status( groups_get_current_group() ) ) {
+			wp_update_post( array(
+				'ID'          => $post_id,
+				'post_status' => 'private'
+			) );
+		}
+	}
+
+	/**
+	 * Bypass various capability checks during ICS event importing.
+	 *
+	 * Group administrators might not have the proper capabilities to create new
+	 * events during ICS imports, so let's bypass them.
+	 *
+	 * Hooked to 'map_meta_cap'.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array  $caps    Capability array.
+	 * @param string $cap     Capability to check.
+	 * @param int    $user_id ID of the user being checked.
+	 * @param array  $args    Miscellaneous args.
+	 * @return array Caps whitelist.
+	 */
+	public function bypass_permission_checks( $caps, $cap, $user_id, $args ) {
+		if ( ! is_user_logged_in() ) {
+			return $caps;
+		}
+
+		switch ( $cap ) {
+			case 'manage_options':
+			case 'edit_events' :
+			case 'manage_venues' :
+				return array( 'exist' );
+				break;
+		}
+
+		return $caps;
 	}
 
 } // class ends

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -828,3 +828,14 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 
 // register our class
 bp_register_group_extension( 'BP_Event_Organiser_Group_Extension' );
+
+// Load our group iCal sync module if necessary.
+add_action( 'bp_init', function() {
+	if ( ! class_exists( 'EO_Sync_Ical' ) || ! bp_is_root_blog() ) {
+		return;
+	}
+
+	require_once BPEO_PATH . 'includes/class.bpeo_group_ical_sync.php';
+
+	$GLOBALS['buddypress_event_organiser']->group_ical_sync = new BPEO_Group_Ical_Sync;
+}, 0 );

--- a/bp-event-organiser-groups.php
+++ b/bp-event-organiser-groups.php
@@ -618,6 +618,16 @@ class BP_Event_Organiser_Group_Extension extends BP_Group_Extension {
 
 			// remove our template stack
 			remove_filter( 'eventorganiser_template_stack', 'bpeo_register_template_stack' );
+
+		/*
+		 * Public group, so add dummy submit button.
+		 *
+		 * The BP Group Extension API adds a submit button by default if one doesn't
+		 * exist. We don't need a submit button because the Import ICS section uses
+		 * a custom form. So to bypass this, we add a hidden submit button.
+		 */
+		} else {
+			echo '<input type="submit" style="display:none" />';
 		}
 	}
 

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -163,6 +163,9 @@ class BPEO_Group_Ical_Sync {
 
 		// Container classes.
 		$classes = array( 'manage-icalendar', 'manage-icalendar-feeds' );
+		if ( true !== bpeo_is_import_assign_organiser_enabled() ) {
+			$classes[] = 'disable-eo-organiser';
+		}
 		if ( true !== bpeo_is_import_categories_enabled() ) {
 			$classes[] = 'disable-eo-categories';
 		}

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -112,6 +112,11 @@ class BPEO_Group_Ical_Sync {
 		// Some markup adjustments.
 		$contents = str_replace( '&lt;br/&gt;', '<br />', $contents );
 
+		// Inject description for hourly cronjob.
+		$cronjob_desc = esc_html__( 'Subscribe to an external calendar by entering the URL of its iCalendar (iCal) feed. Recent events from that calendar will be imported to your group calendar. New events in the feed will be automatically imported every 60 minutes.', 'bp-event-organiser' );
+		$feed_header = __( 'Add New Feed', 'eventorganiserical' ) . '</h4>';
+		$contents = str_replace( $feed_header, $feed_header . '<p>' . $cronjob_desc . '</p>', $contents );
+
 		/**
 		 * Filters the markup from EO's iCal feeds form.
 		 *

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -176,16 +176,20 @@ class BPEO_Group_Ical_Sync {
 		// Output our table.
 		printf( '<div class="%1$s">%2$s</div>', implode( ' ', $classes ), $contents );
 
-		// Inline JS. Hide "Assign events" field if only one person.
+		// Inline JS. Hide "Show Advanced Options" block if no fields to show.
 		$js = "<script>
 			jQuery(function(){
-				var assign = jQuery('#col-left #feed-organiser');
-				if ( 1 === assign.find('option').length ) {
-					assign.closest('.form-field').hide();
-
-					// Hide the quick edit field as well.
-					jQuery('#col-right #feed-organiser').closest('label').hide();
+				var hideAdvanced = true;
+				jQuery('#eo-advanced-feed-options-wrap label').each(function() {
+					if (jQuery(this).css('display') !== 'none' && true === hideAdvanced ) {
+						hideAdvanced = false;
+					}
+				});
+				if ( hideAdvanced ) {
+					jQuery('#eo-advanced-feed-options-wrap').hide();
+					jQuery('p.hide-if-no-js').hide();
 				}
+
 			});
 			</script>
 

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -173,6 +173,24 @@ class BPEO_Group_Ical_Sync {
 		// Output our table.
 		printf( '<div class="%1$s">%2$s</div>', implode( ' ', $classes ), $contents );
 
+		// Inline JS. Hide "Assign events" field if only one person.
+		$js = <<<JS
+
+			<script>
+			jQuery(function($){
+				var assign = $('#col-left #feed-organiser');
+				if ( 1 === assign.find('option').length ) {
+					assign.closest('.form-field').hide();
+
+					// Hide the quick edit field as well.
+					$('#col-right #feed-organiser').closest('label').hide();
+				}
+			});
+			</script>
+
+		JS;
+		echo $js;
+
 		// Cleanup!
 		remove_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
 		remove_action( 'pre_get_posts', array( $this, 'filter_feeds_by_group' ) );

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -200,7 +200,7 @@ class BPEO_Group_Ical_Sync {
 		wp_enqueue_style(
 			'bpeo-manage-group-ical',
 			BUDDYPRESS_EVENT_ORGANISER_URL . 'assets/css/group-manage-ical.css',
-			array( 'list-tables', 'edit', 'buttons' ),
+			array( 'list-tables', 'edit', 'forms' ),
 			'20191105'
 		);
 	}

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -173,7 +173,7 @@ class BPEO_Group_Ical_Sync {
 			'bpeo-manage-group-ical',
 			BUDDYPRESS_EVENT_ORGANISER_URL . 'assets/css/group-manage-ical.css',
 			array( 'list-tables', 'edit', 'forms' ),
-			'20191105'
+			'20191118'
 		);
 	}
 

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -447,7 +447,7 @@ class BPEO_Group_Ical_Sync {
 	public function gettext_overrides( $translated_text, $untranslated_text, $domain ) {
 		switch ( $untranslated_text ) {
 			case 'iCal Feeds' :
-				$translated_text = __( 'Manage iCalendar Feeds', 'bp-event-organiser' );
+				$translated_text = __( 'Subscribed Calendars', 'bp-event-organiser' );
 				break;
 
 			case 'Event status' :

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -50,7 +50,8 @@ class BPEO_Group_Ical_Sync {
 
 		// Remove EO's default cronjob. We're going to roll our own per group.
 		remove_action( 'eventorganiser_ical_feed_sync', 'eo_fetch_feeds' );
-		add_action( 'bpeo_group_ical_sync', array( $this, 'sync' ) );
+		add_action( 'bpeo_group_ical_sync',   array( $this, 'sync' ) );
+		add_action( 'bp_groups_delete_group', array( $this, 'delete_cron_on_group_delete' ) );
 	}
 
 	/* MANAGE > EVENTS PAGE *************************************************/
@@ -205,6 +206,20 @@ class BPEO_Group_Ical_Sync {
 		}
 
 		die();
+	}
+
+	/**
+	 * Removes iCalendar cron job for the group on group deletion.
+	 *
+	 * @param BP_Groups_Group $group Group being deleted.
+	 */
+	public function delete_cron_on_group_delete( $group ) {
+		$schedule_args = array( $group->id );
+
+		$next = wp_next_scheduled( 'bpeo_group_ical_sync', $schedule_args );
+		if ( false !== $next ) {
+			wp_unschedule_event( $next, 'bpeo_group_ical_sync', $schedule_args );
+		}
 	}
 
 	/** SAVE HOOKS **********************************************************/

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -12,8 +12,6 @@ class BPEO_Group_Ical_Sync {
 	 * @since 1.1.0
 	 */
 	public function __construct() {
-		add_filter( 'bpeo_group_show_group_manage_nav', '__return_true' );
-
 		// "Manage > Events" page.
 		add_action( 'bp_actions', array( $this, 'manage_events_ical_feeds' ), 7 );
 

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -33,7 +33,7 @@ class BPEO_Group_Ical_Sync {
 		add_filter( 'eventorganiser_event_color',           array( $this, 'fullcalendar_feed_background_color' ), 10, 2 );
 		add_filter( 'bpeo_get_the_filter_title',            array( $this, 'filter_filter_title' ) );
 		add_action( 'eventorganiser_additional_event_meta', array( $this, 'show_external_feed_data_in_event' ), 40 );
- 
+
 		// Tomfoolery! Save querystring from current URI for AJAX purposes!
 		add_filter( 'bp_uri', function( $retval ) {
 			if ( ! defined( 'DOING_AJAX' ) ) {
@@ -72,22 +72,22 @@ class BPEO_Group_Ical_Sync {
 		// Feed schedule validation routine.
 		if ( ! empty( $_POST['action'] ) && 'eventorganier-update-feed-settings' === $_POST['action'] ) {
 			check_admin_referer( 'eventorganier-update-feed-settings' );
-	
+
 			$schedule = $_POST['eventorganiser_feed_schedule'];
 			$current_schedule = groups_get_groupmeta( bp_get_current_group_id(), 'eventorganiser_feed_schedule' );
-	
+
 			if ( $schedule != $current_schedule ) {
 				$schedule_args = array( bp_get_current_group_id() );
-	
+
 				// Unschedule current cronjob for the group.
 				$next = wp_next_scheduled( 'bpeo_group_ical_sync', $schedule_args );
 				if ( false !== $next ) {
 					wp_unschedule_event( $next, 'bpeo_group_ical_sync', $schedule_args );
 				}
-	
+
 				// Update custom schedule marker.
 				groups_update_groupmeta( bp_get_current_group_id(), 'eventorganiser_feed_schedule', $schedule );
-	
+
 				// Add new cronjob for group.
 				if ( ! empty( $schedule ) ) {
 					$schedules = wp_get_schedules();
@@ -95,7 +95,7 @@ class BPEO_Group_Ical_Sync {
 					wp_schedule_event( $timestamp, $schedule, 'bpeo_group_ical_sync', $schedule_args );
 				}
 			}
-	
+
 			bp_core_add_message( __( 'Feed sync settings updated', 'bp-event-organiser' ) );
 			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/' . $this->get_events_slug() . '/' );
 		}
@@ -196,14 +196,14 @@ class BPEO_Group_Ical_Sync {
 			'meta_key'   => '_eventorganiser_feed_group_id',
 			'meta_value' => $group_id
 		) );
-	
+
 		if ( $feeds ) {
 			foreach ( $feeds as $feed_id ) {
 				set_time_limit( 600 );
 				eo_fetch_feed( $feed_id );
 			}
 		}
-	
+
 		die();
 	}
 
@@ -227,8 +227,6 @@ class BPEO_Group_Ical_Sync {
 		// @todo Make this customizable?
 		update_post_meta( $post_id, '_eventorganiser_feed_color', bpeo_get_item_calendar_color( $feed_id, 'feed' ) );
 	}
-
-
 
 	public function add_group_to_synced_event( $event_id, $event, $feed_id ) {
 		$group_id = (int) get_post_meta( $feed_id, '_eventorganiser_feed_group_id', true );
@@ -360,7 +358,7 @@ class BPEO_Group_Ical_Sync {
 	public function pass_manage_options_cap( $caps, $cap, $user_id, $args ) {
 		if ( ! is_user_logged_in() || 'manage_options' !== $cap ) {
 			return $caps;
-		}		
+		}
 
 		return array( 'exist' );
 	}

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -151,6 +151,15 @@ class BPEO_Group_Ical_Sync {
 		// Some markup adjustments.
 		$contents = str_replace( '&lt;br/&gt;', '<br />', $contents );
 
+		/**
+		 * Filters the markup from EO's iCal feeds form.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $contents HTML markup.
+		 */
+		$contents = apply_filters( 'bpeo_display_ical_feeds_contents', $contents );
+
 		// Container classes.
 		$classes = array( 'manage-icalendar', 'manage-icalendar-feeds' );
 		if ( true !== bpeo_is_import_categories_enabled() ) {

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -462,6 +462,11 @@ class BPEO_Group_Ical_Sync {
 			case 'Published' :
 				$translated_text = __( 'Public', 'bp-event-organiser' );
 				break;
+
+			case 'Source' :
+			case 'Slug' :
+				$translated_text = __( 'iCalendar URL', 'bp-event-organiser' );
+				break;
 		}
 
 		return $translated_text;

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -1,0 +1,384 @@
+<?php
+
+/**
+ * Ical sync module for BuddyPress Groups.
+ *
+ * @since 1.1.0
+ */
+class BPEO_Group_Ical_Sync {
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 */
+	public function __construct() {
+		add_filter( 'bpeo_group_show_group_manage_nav', '__return_true' );
+
+		// "Manage > Events" page.
+		add_action( 'bp_actions', array( $this, 'manage_events_ical_feeds' ), 7 );
+
+		// EO hooks to run on AJAX.
+		add_action( 'wp_ajax_add-eo-feed',    array( $this, 'ajax_mods' ), 0 );
+		add_action( 'wp_ajax_delete-eo-feed', array( $this, 'ajax_mods' ), 0 );
+		add_action( 'wp_ajax_fetch-eo-feed',  array( $this, 'ajax_mods' ), 0 );
+
+		// EO hooks to save our custom BP meta.
+		add_action( 'added_post_meta',                         array( $this, 'save_group_id_to_feed' ), 10, 3 );
+		add_action( 'eventorganiser_ical_sync_event_inserted', array( $this, 'add_group_to_synced_event' ), 10, 3 );
+
+		// EO hooks to display our iCal data.
+		add_filter( 'eventorganiser_fullcalendar_query',    array( $this, 'filter_fullcalendar_query' ) );
+		add_filter( 'eventorganiser_event_color',           array( $this, 'fullcalendar_feed_background_color' ), 10, 2 );
+		add_filter( 'bpeo_get_the_filter_title',            array( $this, 'filter_filter_title' ) );
+		add_action( 'eventorganiser_additional_event_meta', array( $this, 'show_external_feed_data_in_event' ), 40 );
+ 
+		// Tomfoolery! Save querystring from current URI for AJAX purposes!
+		add_filter( 'bp_uri', function( $retval ) {
+			if ( ! defined( 'DOING_AJAX' ) ) {
+				return $retval;
+			}
+
+			// Stash the URI querystring for later.
+			if ( $pos = strpos( $retval, '?' ) ) {
+				buddypress()->bpeo_querystring = substr( $retval, $pos + 1 );
+			}
+
+			return $retval;
+		} );
+
+		// Remove EO's default cronjob. We're going to roll our own per group.
+		remove_action( 'eventorganiser_ical_feed_sync', 'eo_fetch_feeds' );
+		add_action( 'bpeo_group_ical_sync', array( $this, 'sync' ) );
+	}
+
+	/* MANAGE > EVENTS PAGE *************************************************/
+
+	/**
+	 * Screen loader for our "Manage > Events" iCalendar section.
+	 *
+	 * Run on 'bp_actions' at priority 7 so our hook runs before BP's group
+	 * extension validation routine for saving purposes.
+	 *
+	 * @todo Purge all group scheduled events on plugin uninstall.
+	 */
+	public function manage_events_ical_feeds() {
+		// If not on our "Manage > Events" page, bail.
+		if ( true !== ( bp_is_groups_component() && bp_is_current_action( 'admin' ) && bp_is_action_variable( $this->get_events_slug(), 0 ) ) ) {
+			return;
+		}
+
+		// Feed schedule validation routine.
+		if ( ! empty( $_POST['action'] ) && 'eventorganier-update-feed-settings' === $_POST['action'] ) {
+			check_admin_referer( 'eventorganier-update-feed-settings' );
+	
+			$schedule = $_POST['eventorganiser_feed_schedule'];
+			$current_schedule = groups_get_groupmeta( bp_get_current_group_id(), 'eventorganiser_feed_schedule' );
+	
+			if ( $schedule != $current_schedule ) {
+				$schedule_args = array( bp_get_current_group_id() );
+	
+				// Unschedule current cronjob for the group.
+				$next = wp_next_scheduled( 'bpeo_group_ical_sync', $schedule_args );
+				if ( false !== $next ) {
+					wp_unschedule_event( $next, 'bpeo_group_ical_sync', $schedule_args );
+				}
+	
+				// Update custom schedule marker.
+				groups_update_groupmeta( bp_get_current_group_id(), 'eventorganiser_feed_schedule', $schedule );
+	
+				// Add new cronjob for group.
+				if ( ! empty( $schedule ) ) {
+					$schedules = wp_get_schedules();
+					$timestamp = time() + $schedules[ $schedule ]['interval'];
+					wp_schedule_event( $timestamp, $schedule, 'bpeo_group_ical_sync', $schedule_args );
+				}
+			}
+	
+			bp_core_add_message( __( 'Feed sync settings updated', 'bp-event-organiser' ) );
+			bp_core_redirect( bp_get_group_permalink( groups_get_current_group() ) . 'admin/' . $this->get_events_slug() . '/' );
+		}
+
+		// Display hooks.
+		add_action( 'wp_enqueue_scripts',  array( $this, 'enqueue_assets' ) );
+		add_action( 'bp_after_group_body', array( $this, 'manage_events_display_ical_feeds' ) );
+	}
+
+	/**
+	 * Display iCal sync fields.
+	 *
+	 * We're running this on 'bp_after_group_body' because EO has its own form and
+	 * you cannot nest forms within a form.
+	 */
+	public function manage_events_display_ical_feeds() {
+		/*
+		 * EO's iCal sync display method is meant for the admin area.
+		 *
+		 * And requires submit_button(), which is an admin-only function. Since we
+		 * already have some form of admin abstraction for editing single events,
+		 * let's use that.
+		 */
+		require_once BPEO_PATH . 'includes/wp-frontend-admin-screen/abstraction-metabox.php';
+
+		// Only show group admins for Assign Events dropdown and not all users.
+		// @todo Maybe add group mods as well? Or all group members?
+		add_filter( 'wp_dropdown_users_args', function( $retval ) {
+			$retval['include'] = bp_group_admin_ids( groups_get_current_group(), 'array' );
+			return $retval;
+		} );
+
+		// Ensure we fetch the group's custom feed schedule.
+		add_filter( 'pre_option_eventorganiser_feed_schedule', function( $retval ) {
+			$schedule = groups_get_groupmeta( bp_get_current_group_id(), 'eventorganiser_feed_schedule' );
+			if ( ! empty( $schedule ) ) {
+				return $schedule;
+			} else {
+				return 0;
+			}
+		} );
+
+		// Only fetch feeds for the current group.
+		add_action( 'pre_get_posts', array( $this, 'filter_feeds_by_group' ) );
+
+		// Change some strings.
+		add_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
+
+		// Use EO's iCal sync display method.
+		$eo = EO_Sync_Ical::init();
+		ob_start();
+		$eo->display_feeds();
+		$contents = ob_get_clean();
+
+		// Some markup adjustments.
+		$contents = str_replace( '&lt;br/&gt;', '<br />', $contents );
+
+		// Container classes.
+		$classes = array( 'manage-icalendar', 'manage-icalendar-feeds' );
+		if ( true !== bpeo_is_import_categories_enabled() ) {
+			$classes[] = 'disable-eo-categories';
+		}
+		if ( true !== bpeo_is_import_venues_enabled() ) {
+			$classes[] = 'disable-eo-venues';
+		}
+
+		// Output our table.
+		printf( '<div class="%1$s">%2$s</div>', implode( ' ', $classes ), $contents );
+
+		// Cleanup!
+		remove_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
+		remove_action( 'pre_get_posts', array( $this, 'filter_feeds_by_group' ) );
+	}
+
+	public function enqueue_assets() {
+		wp_enqueue_style(
+			'bpeo-manage-group-ical',
+			BUDDYPRESS_EVENT_ORGANISER_URL . 'assets/css/group-manage-ical.css',
+			array( 'list-tables', 'edit', 'buttons' ),
+			'20191105'
+		);
+	}
+
+	/** CRONJOB SYNC ********************************************************/
+
+	public function sync( $group_id ) {
+		$feeds = eo_get_feeds( array(
+			'fields'     => 'ids',
+			'meta_key'   => '_eventorganiser_feed_group_id',
+			'meta_value' => $group_id
+		) );
+	
+		if ( $feeds ) {
+			foreach ( $feeds as $feed_id ) {
+				set_time_limit( 600 );
+				eo_fetch_feed( $feed_id );
+			}
+		}
+	
+		die();
+	}
+
+	/** SAVE HOOKS **********************************************************/
+
+	public function save_group_id_to_feed( $meta_id, $post_id, $meta_key ) {
+		if ( '_eventorganiser_feed_source' !== $meta_key ) {
+			return;
+		}
+
+		// Make sure we're doing this from a BP group page.
+		$group = groups_get_current_group();
+		if ( empty( $group->id ) ) {
+			return;
+		}
+
+		// Save the group ID into the feed's meta.
+		update_post_meta( $post_id, '_eventorganiser_feed_group_id', $group->id );
+
+		// Also save a random feed color.
+		// @todo Make this customizable?
+		update_post_meta( $post_id, '_eventorganiser_feed_color', bpeo_get_item_calendar_color( $feed_id, 'feed' ) );
+	}
+
+
+
+	public function add_group_to_synced_event( $event_id, $event, $feed_id ) {
+		$group_id = (int) get_post_meta( $feed_id, '_eventorganiser_feed_group_id', true );
+		$group    = groups_get_group( $group_id );
+
+		// Sanity check.
+		if ( empty( $group->id ) ) {
+			return;
+		}
+
+		// Connect the event to the group.
+		bpeo_connect_event_to_group( $event_id, $group_id );
+
+		// Also change event status to private if group isn't public.
+		$feed_status = get_post_meta( $feed_id, '_eventorganiser_feed_status', true );
+		if ( '0' === $feed_status && 'public' !== bp_get_group_status( $group ) ) {
+			wp_update_post( array(
+				'ID'          => $event_id,
+				'post_status' => 'private'
+			) );
+		}
+	}
+
+	/**
+	 * AJAX modifications.
+	 *
+	 * We need to bypass the 'manage_options' capability and modify some strings.
+	 */
+	public function ajax_mods() {
+		// If not on our "Manage > Events" page, bail.
+		if ( true !== ( bp_is_groups_component() && bp_is_current_action( 'admin' ) && bp_is_action_variable( $this->get_events_slug(), 0 ) ) ) {
+			return;
+		}
+
+		if ( ! bp_is_item_admin() ) {
+			return;
+		}
+
+		// Disable event category syncing if turned off.
+		if ( true !== bpeo_is_import_categories_enabled() ) {
+			unset( $_POST['feed-category'] );
+		}
+
+		// Disable event venue syncing if turned off.
+		if ( true !== bpeo_is_import_venues_enabled() ) {
+			unset( $_POST['feed-venue'] );
+		}
+
+		// Bypass 'manage_options' capability so we can save our settings.
+		add_filter( 'map_meta_cap', array( $this, 'pass_manage_options_cap' ), 10, 4 );
+
+		// Change some strings.
+		add_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
+	}
+
+	/* DISPLAY HOOKS ********************************************************/
+
+	public function filter_fullcalendar_query( $retval ) {
+		if ( empty( buddypress()->bpeo_querystring ) ) {
+			return $retval;
+		}
+
+		// Parse our stashed querystring.
+		parse_str( buddypress()->bpeo_querystring, $qs );
+
+		if ( ! empty( $qs['ical_feed'] ) ) {
+			$retval['meta_key']   = '_eventorganiser_feed';
+			$retval['meta_value'] = (int) $qs['ical_feed'];
+		}
+
+		return $retval;
+	}
+
+	public function fullcalendar_feed_background_color( $retval, $post_id ) {
+		if ( bp_is_group() && bp_is_current_action( $this->get_events_slug() ) ) {
+			$feed_id = get_post_meta( $post_id, '_eventorganiser_feed', true );
+
+			// Sanity check.
+			if ( empty( $feed_id ) ) {
+				return $retval;
+			}
+
+			// See if our custom color exists, if so use it.
+			$color = get_post_meta( $feed_id, '_eventorganiser_feed_color', true );
+			if ( ! empty( $color ) ) {
+				$retval = "#{$color}";
+			}
+		}
+
+		return $retval;
+	}
+
+	public function filter_filter_title( $retval ) {
+		if ( empty( $_GET['ical_feed'] ) ) {
+			return $retval;
+		}
+
+		return sprintf( __( "Filtered by feed '%s'", 'bp-event-organiser' ), esc_html( get_the_title( (int) $_GET['ical_feed'] ) ) );
+	}
+
+	public function show_external_feed_data_in_event() {
+		// Show this only in groups for now...
+		if ( ! bp_is_group() ) {
+			return;
+		}
+
+		$feed = get_post_meta( get_the_ID(), '_eventorganiser_feed', true );
+		if ( empty( $feed ) ) {
+			return;
+		}
+
+		printf( '<li><strong>' . esc_html( 'Imported from:', 'bp-event-organiser' ) . '</strong> %s</li>',
+			sprintf( '<a href="%1$s">%2$s</a>',
+				esc_url( add_query_arg( 'ical_feed', (int) $feed, bpeo_get_group_permalink() ) ),
+				esc_html( get_the_title( (int) $feed ) )
+			)
+		);
+	}
+
+	/* MISC CALLBACKS / HELPERS *********************************************/
+
+	public function filter_feeds_by_group( $q ) {
+		$q->set( 'meta_key',   '_eventorganiser_feed_group_id' );
+		$q->set( 'meta_value', bp_get_current_group_id() );
+	}
+
+	public function pass_manage_options_cap( $caps, $cap, $user_id, $args ) {
+		if ( ! is_user_logged_in() || 'manage_options' !== $cap ) {
+			return $caps;
+		}		
+
+		return array( 'exist' );
+	}
+
+	public function gettext_overrides( $translated_text, $untranslated_text, $domain ) {
+		switch ( $untranslated_text ) {
+			case 'iCal Feeds' :
+				$translated_text = __( 'Manage iCalendar Feeds', 'bp-event-organiser' );
+				break;
+
+			case 'Event status' :
+			case 'Event Status' :
+				$translated_text = __( 'Event privacy', 'bp-event-organiser' );
+				break;
+
+			case 'Use status specified in feed' :
+				$translated_text = __( 'Inherit group privacy', 'bp-event-organiser' );
+				break;
+
+			case 'Published' :
+				$translated_text = __( 'Public', 'bp-event-organiser' );
+				break;
+		}
+
+		return $translated_text;
+	}
+
+	protected function get_events_slug() {
+		/** This filter is documented in /bp-event-organiser-groups.php */
+		$slug = apply_filters( 'bpeo_extension_slug', bpeo_get_events_slug() );
+
+		return $slug;
+	}
+}

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -174,21 +174,19 @@ class BPEO_Group_Ical_Sync {
 		printf( '<div class="%1$s">%2$s</div>', implode( ' ', $classes ), $contents );
 
 		// Inline JS. Hide "Assign events" field if only one person.
-		$js = <<<JS
-
-			<script>
-			jQuery(function($){
-				var assign = $('#col-left #feed-organiser');
+		$js = "<script>
+			jQuery(function(){
+				var assign = jQuery('#col-left #feed-organiser');
 				if ( 1 === assign.find('option').length ) {
 					assign.closest('.form-field').hide();
 
 					// Hide the quick edit field as well.
-					$('#col-right #feed-organiser').closest('label').hide();
+					jQuery('#col-right #feed-organiser').closest('label').hide();
 				}
 			});
 			</script>
 
-		JS;
+		";
 		echo $js;
 
 		// Cleanup!

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -122,10 +122,7 @@ class BPEO_Group_Ical_Sync {
 
 		// Only show group admins for Assign Events dropdown and not all users.
 		// @todo Maybe add group mods as well? Or all group members?
-		add_filter( 'wp_dropdown_users_args', function( $retval ) {
-			$retval['include'] = bp_group_admin_ids( groups_get_current_group(), 'array' );
-			return $retval;
-		} );
+		add_filter( 'wp_dropdown_users_args', array( $this, 'limit_dropdown_members_to_group_admins' ) );
 
 		// Ensure we fetch the group's custom feed schedule.
 		add_filter( 'pre_option_eventorganiser_feed_schedule', function( $retval ) {
@@ -190,7 +187,8 @@ class BPEO_Group_Ical_Sync {
 		echo $js;
 
 		// Cleanup!
-		remove_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
+		remove_filter( 'gettext', array( $this, 'gettext_overrides' ), 10 );
+		remove_filter( 'wp_dropdown_users_args', array( $this, 'limit_dropdown_members_to_group_admins' ) );
 		remove_action( 'pre_get_posts', array( $this, 'filter_feeds_by_group' ) );
 	}
 
@@ -302,6 +300,9 @@ class BPEO_Group_Ical_Sync {
 
 		// Change some strings.
 		add_filter( 'gettext', array( $this, 'gettext_overrides' ), 10, 3 );
+
+		// Limit members dropdown to group admins only.
+		add_filter( 'wp_dropdown_users_args', array( $this, 'limit_dropdown_members_to_group_admins' ) );
 	}
 
 	/**
@@ -450,6 +451,17 @@ class BPEO_Group_Ical_Sync {
 		}
 
 		return $translated_text;
+	}
+
+	/**
+	 * Limit member dropdown to group admins only instead of all users.
+	 *
+	 * @param  array $retval Query args.
+	 * @return array
+	 */
+	public function limit_dropdown_members_to_group_admins( $retval ) {
+		$retval['include'] = bp_group_admin_ids( groups_get_current_group(), 'array' );
+		return $retval;
 	}
 
 	protected function get_events_slug() {

--- a/includes/class.bpeo_group_ical_sync.php
+++ b/includes/class.bpeo_group_ical_sync.php
@@ -252,7 +252,7 @@ class BPEO_Group_Ical_Sync {
 
 		// Also save a random feed color.
 		// @todo Make this customizable?
-		update_post_meta( $post_id, '_eventorganiser_feed_color', bpeo_get_item_calendar_color( $feed_id, 'feed' ) );
+		update_post_meta( $post_id, '_eventorganiser_feed_color', bpeo_get_item_calendar_color( $post_id, 'feed' ) );
 	}
 
 	public function add_group_to_synced_event( $event_id, $event, $feed_id ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -726,7 +726,6 @@ function bpeo_get_item_calendar_color( $item_id, $item_type ) {
 			break;
 
 		case 'author' :
-		default :
 			$color = bp_get_user_meta( $item_id, 'bpeo_calendar_color', true );
 			break;
 	}
@@ -767,7 +766,6 @@ function bpeo_get_item_calendar_color( $item_id, $item_type ) {
 				break;
 
 			case 'author' :
-			default :
 				bp_update_user_meta( $item_id, 'bpeo_calendar_color', $color );
 				break;
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -844,6 +844,26 @@ add_filter( 'ajax_query_attachments_args', 'bpeo_filter_ajax_query_attachments' 
 /** Import ICS ***************************************************************/
 
 /**
+ * Can an imported event be assigned to a different user?
+ *
+ * @since 1.1.0
+ *
+ * @return bool
+ */
+function bpeo_is_import_assign_organiser_enabled() {
+	/**
+	 * Filter to toggle if a different user can be assigned to an imported event.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param bool $retval Default: false
+	 */
+	$retval = apply_filters( 'bpeo_enable_import_assign_organiser', false );
+
+	return $retval;
+}
+
+/**
  * See if categories can be imported from an ICS file.
  *
  * @since 1.1.0

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -180,7 +180,16 @@ function bpeo_the_filter_title() {
 		} elseif ( ! empty( $tag ) ) {
 			return sprintf( __( "Filtered by tag '%s'", 'bp-event-organiser' ), $tag );
 		} else {
-			return '';
+			/**
+			 * Allow developers to set a filter title when blank.
+			 *
+			 * @since 1.1.0
+			 *
+			 * @param string $title.
+			 */
+			$title = apply_filters( 'bpeo_get_the_filter_title', '' );
+
+			return esc_html( $title );
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -839,3 +839,46 @@ function bpeo_filter_ajax_query_attachments( $retval ) {
 	return $retval;
 }
 add_filter( 'ajax_query_attachments_args', 'bpeo_filter_ajax_query_attachments' );
+
+
+/** Import ICS ***************************************************************/
+
+/**
+ * See if categories can be imported from an ICS file.
+ *
+ * @since 1.1.0
+ *
+ * @return bool
+ */
+function bpeo_is_import_categories_enabled() {
+	/**
+	 * Filter to toggle if categories can be imported from an ICS file.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param bool $retval Default: true
+	 */
+	$retval = apply_filters( 'bpeo_enable_import_categories', true );
+
+	return $retval;
+}
+
+/**
+ * See if venues can be imported from an ICS file.
+ *
+ * @since 1.1.0
+ *
+ * @return bool
+ */
+function bpeo_is_import_venues_enabled() {
+	/**
+	 * Filter to toggle if venues can be imported from an ICS file.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param bool $retval Default: true
+	 */
+	$retval = apply_filters( 'bpeo_enable_import_venues', true );
+
+	return $retval;
+}


### PR DESCRIPTION
We did this for the Commons, but we might want to consider merging this branch into 1.1.x or consider doing this in a future release.

To summarize, this PR allows for groups to import events from an uploaded ICS file or to import events from an iCalendar URL. Importing from an iCalendar URL will automatically set up a cronjob for the group to sync events every hour.

**Note:** The iCalendar URL import requires [Event Organiser's iCal Sync](https://wp-event-organiser.com/extensions/event-organiser-ical-sync/) premium extension